### PR TITLE
Use configured API prefix for routes

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -20,8 +20,10 @@ app.add_middleware(
 # Import and include routers
 from .routers import projects, contact
 
-app.include_router(projects.router, prefix="/api/projects", tags=["projects"])
-app.include_router(contact.router, prefix="/api/contact", tags=["contact"])
+# Use the configured API prefix from settings to avoid hard-coded paths
+api_prefix = settings.API_V1_STR
+app.include_router(projects.router, prefix=f"{api_prefix}/projects", tags=["projects"])
+app.include_router(contact.router, prefix=f"{api_prefix}/contact", tags=["contact"])
 
 @app.get("/")
 async def root():

--- a/apps/api/app/tests/test_main.py
+++ b/apps/api/app/tests/test_main.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import unittest
+
+from fastapi.testclient import TestClient
+
+# Ensure the app package is importable when running tests from repo root
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from app.main import app
+from app.core.config import settings
+
+class TestAPI(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_root_endpoint(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"message": "Welcome to the Portfolio API"})
+
+    def test_projects_prefix_uses_setting(self):
+        response = self.client.get(f"{settings.API_V1_STR}/projects")
+        self.assertEqual(response.status_code, 200)
+        self.assertIsInstance(response.json(), list)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use settings.API_V1_STR for route prefixes instead of hard-coded paths
- add unittest verifying root and project routes

## Testing
- `pnpm test` *(fails: turbo not found)*
- `python apps/api/app/tests/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_689d720f1c7c8326add4316a3148a4c7