### PR TITLE
chore: add api pyproject and refine ci

### DIFF
--- a/.cursor/context/IMPLEMENTATION_PLAN.md
+++ b/.cursor/context/IMPLEMENTATION_PLAN.md
@@ -11,9 +11,10 @@
 - Responsive design and a11y checks.
 
 ## Week 2 — Backend & Wiring
-- FastAPI: `/api/projects` (reads JSON), `/api/contact` (send email).  
-- Add CORS.  
+- FastAPI: `/api/projects` (reads JSON), `/api/contact` (send email).
+- Add CORS.
 - Connect FE to BE; handle loading/error states; user‑visible success message.
+- Initialize backend packaging with `pyproject.toml` and ensure CI installs the app in editable mode.
 
 ## Week 3 — Hardening & Deploy
 - Tests (pytest; minimal FE tests).  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,24 +42,22 @@ jobs:
         run: pnpm --filter web format
 
       - name: Lint backend
+        working-directory: apps/api
         run: |
-          cd apps/api
-          pip install ruff mypy
+          pip install -e .[dev]
           ruff check .
           mypy .
 
       - name: Format check backend
-        run: |
-          cd apps/api
-          ruff format --check .
+        working-directory: apps/api
+        run: ruff format --check .
 
       - name: Build frontend
         run: pnpm --filter web build
 
       - name: Build backend
-        run: |
-          cd apps/api
-          pip install -e .
+        working-directory: apps/api
+        run: pip install -e .
 
   test:
     runs-on: ubuntu-latest
@@ -91,9 +89,9 @@ jobs:
         run: pnpm --filter web test
 
       - name: Run backend tests
+        working-directory: apps/api
         run: |
-          cd apps/api
-          pip install pytest pytest-asyncio httpx
+          pip install -e .[dev]
           pytest
 
   security:

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "portfolio-api"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi==0.116.1",
+    "uvicorn[standard]==0.35.0",
+    "sqlalchemy==2.0.43",
+    "psycopg2-binary==2.9.10",
+    "alembic==1.16.4",
+    "pydantic==2.11.7",
+    "pydantic-settings==2.10.1",
+    "email-validator==2.2.0",
+    "python-multipart==0.0.20",
+    "python-jose[cryptography]==3.5.0",
+    "passlib[bcrypt]==1.7.4",
+    "python-dotenv==1.1.1",
+    "requests==2.31.0",
+    "aiohttp==3.9.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==8.4.1",
+    "pytest-asyncio==1.1.0",
+    "httpx==0.28.1",
+    "black==25.1.0",
+    "ruff==0.12.9",
+    "mypy==1.11.1",
+]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["app*"]


### PR DESCRIPTION
## Summary
- package FastAPI backend via pyproject.toml
- refine CI to install backend in editable mode
- note packaging step in implementation plan

## Testing
- `ruff check .` *(fails: E402, F401, ...)*
- `mypy .` *(fails: variable not valid as type, etc.)*
- `ruff format --check .` *(fails: would reformat files)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10795d99c8326a858abbbb52f2c38