### PR TITLE
chore(ci): streamline backend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Lint backend
         working-directory: apps/api
         run: |
-          pip install -e .[dev]
           ruff check .
           mypy .
 
@@ -57,7 +56,7 @@ jobs:
 
       - name: Build backend
         working-directory: apps/api
-        run: pip install -e .
+        run: pip install -e .[dev]
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- streamline CI backend build to install dev deps once
- drop duplicate backend install during linting

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: InvalidManifestError: Expected string got int)*
- `pnpm install` *(fails: ERR_PNPM_META_FETCH_FAIL: Value of "this" must be of type URLSearchParams)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a119d1160c83269909c5a2cb96eab1