### PR TITLE
chore(api): ignore alembic context attr-defined

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -5,7 +5,7 @@ import os
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
-from alembic import context
+from alembic import context  # type: ignore[attr-defined]
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
## Summary
- silence mypy attr-defined warning for Alembic context import

## Testing
- `SKIP=eslint pre-commit run --files apps/api/alembic/env.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*
- `mypy apps/api` *(fails: Found 62 errors in 14 files (checked 37 source files))*


------
https://chatgpt.com/codex/tasks/task_e_68a13f8e4b188326955b440058f29086