### PR TITLE
refactor: modernize pydantic configuration

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import List
 import os
 
@@ -43,8 +43,7 @@ class Settings(BaseSettings):
     GITHUB_USERNAME: str = "googa27"
     GITHUB_API_URL: str = "https://api.github.com"
 
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 
 settings = Settings()

--- a/apps/api/app/models/database.py
+++ b/apps/api/app/models/database.py
@@ -1,6 +1,5 @@
 from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import declarative_base, relationship
 from datetime import datetime
 
 Base = declarative_base()

--- a/apps/api/app/schemas/contact.py
+++ b/apps/api/app/schemas/contact.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, ConfigDict
 from datetime import datetime
 
 
@@ -16,8 +16,7 @@ class Contact(ContactBase):
     id: int
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ContactResponse(BaseModel):

--- a/apps/api/app/schemas/cv.py
+++ b/apps/api/app/schemas/cv.py
@@ -10,7 +10,7 @@ These models define the structure for CV data that can be:
 
 from datetime import datetime
 from typing import List, Optional, Dict, Any
-from pydantic import BaseModel, HttpUrl, Field, validator
+from pydantic import BaseModel, HttpUrl, Field, field_validator, ConfigDict
 from enum import Enum
 
 
@@ -57,7 +57,7 @@ class WorkExperience(BaseModel):
     )
     is_current: bool = Field(False, description="Whether this is the current position")
 
-    @validator("is_current", pre=True, always=True)
+    @field_validator("is_current", mode="before")
     def set_is_current(cls, v, values):
         """Automatically set is_current based on end_date."""
         if "end_date" in values and values["end_date"] is None:
@@ -188,8 +188,9 @@ class CVProfile(BaseModel):
     linkedin_url: HttpUrl = Field(..., description="LinkedIn profile URL")
     version: str = Field(default="1.0", description="CV version")
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
             "example": {
                 "personal_info": {
                     "first_name": "Cristobal",
@@ -201,7 +202,8 @@ class CVProfile(BaseModel):
                 },
                 "version": "1.0",
             }
-        }
+        },
+    )
 
 
 class CVExportRequest(BaseModel):

--- a/apps/api/app/schemas/project.py
+++ b/apps/api/app/schemas/project.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, HttpUrl, Field
+from pydantic import BaseModel, HttpUrl, Field, ConfigDict
 from typing import List, Optional
 from datetime import datetime
 from enum import Enum
@@ -62,8 +62,9 @@ class ProjectShowcase(BaseModel):
     forks: int = 0
     last_updated: datetime
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        from_attributes=True,
+        json_schema_extra={
             "example": {
                 "project_id": 1,
                 "name": "Finite Difference Options Pricing",
@@ -84,7 +85,8 @@ class ProjectShowcase(BaseModel):
                     "Risk analysis",
                 ],
             }
-        }
+        },
+    )
 
 
 class ProjectBase(BaseModel):
@@ -105,8 +107,7 @@ class ProjectCreate(ProjectBase):
 class Project(ProjectBase):
     id: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ProjectList(BaseModel):


### PR DESCRIPTION
## Summary
- import `declarative_base` from `sqlalchemy.orm`
- migrate schemas to `ConfigDict` and `field_validator`
- update settings to `SettingsConfigDict`

## Testing
- `ruff check app`
- `mypy app`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14176f57483269badc6750ddc3e90