### PR TITLE
ci: install backend deps before lint

### DIFF
--- a/.cursor/context/IMPLEMENTATION_PLAN.md
+++ b/.cursor/context/IMPLEMENTATION_PLAN.md
@@ -14,7 +14,7 @@
 - FastAPI: `/api/projects` (reads JSON), `/api/contact` (send email).
 - Add CORS.
 - Connect FE to BE; handle loading/error states; user‑visible success message.
-- Initialize backend packaging with `pyproject.toml` and ensure CI installs the app in editable mode.
+- Initialize backend packaging with `pyproject.toml` and ensure CI installs the app in editable mode before linting.
 
 ## Week 3 — Hardening & Deploy
 - Tests (pytest; minimal FE tests).  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Format check frontend
         run: pnpm --filter web format
 
+      - name: Install backend dependencies
+        working-directory: apps/api
+        run: pip install -e .[dev]
+
       - name: Lint backend
         working-directory: apps/api
         run: |
@@ -53,10 +57,6 @@ jobs:
 
       - name: Build frontend
         run: pnpm --filter web build
-
-      - name: Build backend
-        working-directory: apps/api
-        run: pip install -e .[dev]
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- install backend dependencies before linting in quality-checks job
- document CI installation order in implementation plan

## Testing
- `ruff check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68a1448e5e988326851be6c611064d99