### PR TITLE
fix: install pnpm before setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -23,11 +28,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install
@@ -65,6 +65,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -75,11 +80,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install
@@ -100,16 +100,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- install pnpm before calling setup-node in CI workflow to ensure caching step finds pnpm

## Testing
- `pnpm install`
- `pnpm --filter web lint` (fails: ESLint couldn't find the config "@repo/config/eslint")
- `pnpm --filter web typecheck`
- `pnpm --filter web format`
- `pnpm --filter web build`
- `pnpm --filter web test`
- `pip install -e .[dev]`
- `ruff check .`
- `mypy .`
- `ruff format --check .`
- `pytest`
- `pnpm audit --audit-level moderate`


------
https://chatgpt.com/codex/tasks/task_e_68a19db5ec48832693a47d1077bd637c