### PR TITLE
chore(api): require Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A modern, recruiter-friendly portfolio website built with Next.js, FastAPI, and 
 
 ### Backend
 - **Framework**: FastAPI
-- **Language**: Python 3.11+
+- **Language**: Python 3.12+
 - **Validation**: Pydantic
 - **CORS**: Built-in middleware
 - **Server**: Uvicorn
@@ -64,7 +64,7 @@ A modern, recruiter-friendly portfolio website built with Next.js, FastAPI, and 
 ### Prerequisites
 
 - **Node.js**: 22+
-- **Python**: 3.11+
+- **Python**: 3.12+
 - **pnpm**: 10+
 
 ### Installation

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,6 @@
     "build": "echo 'FastAPI app built successfully'"
   },
   "engines": {
-    "python": ">=3.12.0"
+    "python": ">=3.12"
   }
 }

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "FastAPI backend service for the portfolio website"
 authors = [{ name = "Portfolio Maintainers" }]
 license = {text = "MIT"}
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "fastapi==0.116.1",
     "uvicorn[standard]==0.35.0",


### PR DESCRIPTION
## Summary
- align API configuration and documentation on Python 3.12 minimum
- update engine constraints in api package.json and pyproject

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a259ecd64c8326b4707441a662f08c