### PR TITLE
chore(api): bump http client dependencies

### DIFF
--- a/.cursor/context/CHANGELOG.md
+++ b/.cursor/context/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- Updated `requests` dependency to `2.32.4` and `aiohttp` to `3.12.15` in API service configuration.

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "python-jose[cryptography]==3.5.0",
     "passlib[bcrypt]==1.7.4",
     "python-dotenv==1.1.1",
-    "requests==2.31.0",
-    "aiohttp==3.9.1",
+    "requests==2.32.4",
+    "aiohttp==3.12.15",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,6 +10,6 @@ python-multipart==0.0.20
 python-jose[cryptography]==3.5.0
 passlib[bcrypt]==1.7.4
 python-dotenv==1.1.1
-requests==2.31.0
-aiohttp==3.9.1
+requests==2.32.4
+aiohttp==3.12.15
 httpx==0.28.1


### PR DESCRIPTION
## Summary
- bump requests to 2.32.4 and aiohttp to 3.12.15
- document API dependency upgrades

## Testing
- `pip install -r apps/api/requirements-dev.txt`
- `pip install -e .`
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68a25cbb349c83268d5346004341ffc3