### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/packages/ui"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ pnpm --filter web format    # Prettier
 pnpm --filter web typecheck # TypeScript compiler
 ```
 
+### Automated Dependency Updates
+Dependabot monitors the npm workspaces in `apps/web` and `packages/ui` as well as Python dependencies in `apps/api`. It runs weekly and opens pull requests that trigger the full CI pipeline to test and lint updates automatically.
+
 ## 🚀 Deployment
 
 ### Frontend (Vercel)


### PR DESCRIPTION
## Summary
- configure Dependabot to update npm workspaces and Python dependencies weekly
- document automated dependency updates in the README

## Testing
- `pnpm lint` *(fails: ESLint couldn't find a config in @repo/ui)*
- `pnpm --filter web lint`
- `pnpm --filter api lint`
- `pnpm test` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68a2642807c48326bcb1c51fb13797a2