### PR TITLE
chore(ci): use Python 3.12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pnpm install
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary
- use Python 3.12 for quality checks and tests

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: npm error Unsupported URL Type "workspace:")*
- `pnpm --filter web test`
- `pip install -e .[dev]`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a26f2b499083269b5038983f037bf2