### PR TITLE
Update architecture zizmor pin to 1.28.0

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -195,18 +195,18 @@
       {
         "capability": "GitHub Actions static security audit",
         "selected": [
-          "Zizmor 1.27.0"
+          "Zizmor 1.28.0"
         ],
         "alternatives": [
           "Ad hoc workflow regex checks only"
         ],
-        "evidence": "requirements-architecture.txt and https://github.com/woodruffw/zizmor",
+        "evidence": "requirements-architecture.txt and https://github.com/zizmorcore/zizmor",
         "adapter_boundary": "Offline CI audit of .github workflow definitions; no application runtime coupling.",
         "custom_code_reason": "The local checker owns portfolio-specific policy while Zizmor supplies maintained security rules.",
-        "maintenance_evidence": "https://github.com/woodruffw/zizmor/releases/tag/v1.27.0",
+        "maintenance_evidence": "https://github.com/zizmorcore/zizmor/releases/tag/v1.28.0",
         "api_stability_evidence": "https://docs.zizmor.sh/",
-        "license_evidence": "https://github.com/woodruffw/zizmor/blob/v1.27.0/MIT-LICENSE.txt",
-        "api_license_evidence": "https://github.com/woodruffw/zizmor/blob/v1.27.0/MIT-LICENSE.txt",
+        "license_evidence": "https://github.com/zizmorcore/zizmor/blob/v1.28.0/LICENSE",
+        "api_license_evidence": "https://github.com/zizmorcore/zizmor/blob/v1.28.0/LICENSE",
         "oracle_or_reference_tests": [
           ".github/workflows/ai-hierarchy-policy.yml",
           "scripts/selftest_ai_hierarchy_policy.py"
@@ -361,7 +361,7 @@
       "security_audit_command": "zizmor --offline --min-severity medium .",
       "validated_versions": {
         "pinact": "4.1.0",
-        "zizmor": "1.27.0",
+        "zizmor": "1.28.0",
         "pyyaml": "6.0.3"
       },
       "evidence": [

--- a/requirements-architecture.txt
+++ b/requirements-architecture.txt
@@ -1,2 +1,2 @@
 PyYAML==6.0.3
-zizmor==1.27.0
+zizmor==1.28.0


### PR DESCRIPTION
## Summary
- update requirements-architecture zizmor pin to 1.28.0
- refresh architecture evidence for zizmorcore/zizmor v1.28.0 release and LICENSE path
- assert legacy woodruffw/v1.27/MIT-LICENSE references are removed

## Verification
- `python3 -m venv .venv-architecture && . .venv-architecture/bin/activate && python -m pip install --upgrade pip && python -m pip install -r requirements-architecture.txt && python -m pip show zizmor PyYAML`
- `env -u GITHUB_TOKEN -u GH_TOKEN -u GITHUB_AUTH_TOKEN -u ACTIONS_ID_TOKEN_REQUEST_TOKEN zizmor --offline --min-severity medium .`
- `python scripts/check_portfolio_architecture.py`
- `python3 scripts/check_ai_hierarchy_policy.py`
- `python scripts/selftest_ai_hierarchy_policy.py`
- `python -m pip install pytest==9.0.3 && python -m pytest tests/architecture`
- `git grep -n -E '1\\.27\\.0|v1\\.27\\.0|woodruffw/zizmor|MIT-LICENSE\\.txt' -- . || true`

Refs googa27/PDP#255

Do not merge: opened for review and CI only.
