### PR TITLE
Upgrade backend aiohttp to 3.14.3

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "passlib[bcrypt]==1.7.4",
     "python-dotenv==1.2.2",
     "requests==2.34.2",
-    "aiohttp==3.14.1",
+    "aiohttp==3.14.3",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,5 +10,5 @@ python-multipart==0.0.32
 passlib[bcrypt]==1.7.4
 python-dotenv==1.2.2
 requests==2.34.2
-aiohttp==3.14.1
+aiohttp==3.14.3
 httpx==0.28.1


### PR DESCRIPTION
## Executive summary

Updates both backend dependency manifests from aiohttp 3.14.1 to 3.14.3, fixing CVE-2026-59881, CVE-2026-69243, and CVE-2026-69244 without source/API changes.

Closes #96. Portfolio parent: googa27/PDP#255.

## Verification

```text
requirements pip-audit          PASS — no known vulnerabilities
pyproject environment audit     PASS — no known vulnerabilities
backend tests                    PASS — 13
architecture contract           PASS
manifest consistency            PASS
independent review              APPROVED — no findings
```

## Risk / rollback

Low patch-level dependency change. Do not restore aiohttp 3.14.1; rollback means selecting another release at or above the advisory fix floor and rerunning both audits/tests.
