### PR TITLE
Make optional API timestamps timezone-aware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           python -m pip install pip-audit
           pip-audit -r apps/api/requirements.txt
+          pip-audit -r apps/api/requirements-dev.txt
 
   osv-pr-scan:
     if: ${{ github.event_name == 'pull_request' }}

--- a/apps/api/app/core/time.py
+++ b/apps/api/app/core/time.py
@@ -1,0 +1,47 @@
+"""Shared timezone-aware timestamp contracts for the optional API."""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime
+from sqlalchemy.engine.interfaces import Dialect
+from sqlalchemy.types import TypeDecorator
+
+
+def as_utc(value: datetime) -> datetime:
+    """Interpret a naive legacy value as UTC or convert an aware value to UTC."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def parse_utc(value: str | datetime | None) -> datetime | None:
+    """Parse a GitHub/ISO timestamp and normalize it to aware UTC."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return as_utc(value)
+    return as_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
+def utc_now() -> datetime:
+    """Return the current time as an aware UTC datetime."""
+    return datetime.now(UTC)
+
+
+class UTCDateTime(TypeDecorator[datetime]):
+    """Persist UTC and restore tzinfo lost by SQLite or legacy database rows."""
+
+    impl = DateTime(timezone=True)
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: datetime | None, dialect: Dialect
+    ) -> datetime | None:
+        del dialect
+        return as_utc(value) if value is not None else None
+
+    def process_result_value(
+        self, value: datetime | None, dialect: Dialect
+    ) -> datetime | None:
+        del dialect
+        return as_utc(value) if value is not None else None

--- a/apps/api/app/models/database.py
+++ b/apps/api/app/models/database.py
@@ -1,6 +1,7 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, ForeignKey
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import declarative_base, relationship
-from datetime import datetime
+
+from app.core.time import UTCDateTime, utc_now
 
 Base = declarative_base()
 
@@ -20,8 +21,8 @@ class Project(Base):
     forks = Column(Integer, default=0)
     topics = Column(Text)  # JSON string of topics
     is_featured = Column(Boolean, default=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(UTCDateTime(), default=utc_now)
+    updated_at = Column(UTCDateTime(), default=utc_now, onupdate=utc_now)
 
 
 class Contact(Base):
@@ -35,7 +36,7 @@ class Contact(Base):
     message = Column(Text, nullable=False)
     ip_address = Column(String(45))  # IPv6 compatible
     user_agent = Column(Text)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(UTCDateTime(), default=utc_now)
     is_read = Column(Boolean, default=False)
 
 
@@ -48,8 +49,8 @@ class ChatSession(Base):
     session_id = Column(String(255), unique=True, index=True)
     ip_address = Column(String(45))
     user_agent = Column(Text)
-    created_at = Column(DateTime, default=datetime.utcnow)
-    last_activity = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    created_at = Column(UTCDateTime(), default=utc_now)
+    last_activity = Column(UTCDateTime(), default=utc_now, onupdate=utc_now)
 
     # Relationship to messages
     messages = relationship("ChatMessage", back_populates="session")
@@ -64,7 +65,7 @@ class ChatMessage(Base):
     session_id = Column(Integer, ForeignKey("chat_sessions.id"))
     role = Column(String(50), nullable=False)  # 'user' or 'assistant'
     content = Column(Text, nullable=False)
-    timestamp = Column(DateTime, default=datetime.utcnow)
+    timestamp = Column(UTCDateTime(), default=utc_now)
 
     # Relationship to session
     session = relationship("ChatSession", back_populates="messages")
@@ -78,5 +79,5 @@ class CVDownload(Base):
     id = Column(Integer, primary_key=True, index=True)
     ip_address = Column(String(45))
     user_agent = Column(Text)
-    download_date = Column(DateTime, default=datetime.utcnow)
+    download_date = Column(UTCDateTime(), default=utc_now)
     referrer = Column(String(500))  # Where they came from

--- a/apps/api/app/schemas/cv.py
+++ b/apps/api/app/schemas/cv.py
@@ -13,6 +13,8 @@ from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, HttpUrl, Field, field_validator, ConfigDict
 from enum import Enum
 
+from app.core.time import as_utc, utc_now
+
 
 class SkillLevel(str, Enum):
     """Skill proficiency levels."""
@@ -119,11 +121,10 @@ class Skills(BaseModel):
     def get_all_skills(self) -> List[Skill]:
         """Get all skills as a flat list."""
         all_skills = []
-        for field in self.__fields__.values():
-            if hasattr(self, field.name):
-                skills = getattr(self, field.name)
-                if isinstance(skills, list):
-                    all_skills.extend(skills)
+        for field_name in type(self).model_fields:
+            skills = getattr(self, field_name)
+            if isinstance(skills, list):
+                all_skills.extend(skills)
         return all_skills
 
     def get_skills_by_category(self, category: str) -> List[Skill]:
@@ -183,10 +184,16 @@ class CVProfile(BaseModel):
         default_factory=list, description="Language proficiencies"
     )
     last_updated: datetime = Field(
-        default_factory=datetime.utcnow, description="Last update timestamp"
+        default_factory=utc_now, description="Last update timestamp"
     )
     linkedin_url: HttpUrl = Field(..., description="LinkedIn profile URL")
     version: str = Field(default="1.0", description="CV version")
+
+    @field_validator("last_updated", mode="after")
+    @classmethod
+    def normalize_last_updated(cls, value: datetime) -> datetime:
+        """Normalize supplied and legacy CV timestamps to aware UTC."""
+        return as_utc(value)
 
     model_config = ConfigDict(
         from_attributes=True,

--- a/apps/api/app/services/cv.py
+++ b/apps/api/app/services/cv.py
@@ -10,10 +10,11 @@ This service handles:
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, Optional, Any
 from pathlib import Path
 
+from app.core.time import utc_now
 from app.schemas.cv import (
     CVProfile,
     CVExportRequest,
@@ -70,7 +71,7 @@ class CVService:
                 return LinkedInSyncResponse(
                     success=False,
                     message="LinkedIn service not configured",
-                    last_sync=datetime.now(timezone.utc),
+                    last_sync=utc_now(),
                     data_updated=False,
                     changes=None,
                 )
@@ -84,7 +85,7 @@ class CVService:
                 return LinkedInSyncResponse(
                     success=False,
                     message="Failed to sync from LinkedIn",
-                    last_sync=datetime.now(timezone.utc),
+                    last_sync=utc_now(),
                     data_updated=False,
                     changes=None,
                 )
@@ -111,7 +112,7 @@ class CVService:
                 message="CV synced successfully from LinkedIn",
                 last_sync=datetime.fromisoformat(sync_status["last_sync"])
                 if sync_status["last_sync"]
-                else datetime.now(timezone.utc),
+                else utc_now(),
                 data_updated=bool(changes),
                 changes=changes,
             )
@@ -121,7 +122,7 @@ class CVService:
             return LinkedInSyncResponse(
                 success=False,
                 message=f"Sync failed: {str(e)}",
-                last_sync=datetime.now(timezone.utc),
+                last_sync=utc_now(),
                 data_updated=False,
                 changes=None,
             )
@@ -189,8 +190,7 @@ class CVService:
     ) -> CVExportResponse:
         """Export CV as JSON."""
         try:
-            # Convert to dict with export options
-            export_data = cv_profile.dict()
+            export_data = cv_profile.model_dump()
 
             # Apply export options
             if not request.include_scores:
@@ -238,7 +238,7 @@ class CVService:
             pdf_content = f"""
             CV Export - {cv_profile.personal_info.first_name} {cv_profile.personal_info.last_name}
             Format: PDF
-            Generated: {datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")}
+            Generated: {utc_now().strftime("%Y-%m-%d %H:%M:%S UTC")}
             
             Note: PDF export is not yet implemented.
             Please use JSON or MDX format for now.
@@ -528,7 +528,7 @@ class CVService:
         """Save CV profile to storage."""
         try:
             # Serialize dates for JSON storage
-            cv_data = self._serialize_dates(cv_profile.dict())
+            cv_data = self._serialize_dates(cv_profile.model_dump())
 
             with open(self.cv_data_file, "w", encoding="utf-8") as f:
                 json.dump(cv_data, f, indent=2, ensure_ascii=False)

--- a/apps/api/app/services/github_service.py
+++ b/apps/api/app/services/github_service.py
@@ -1,6 +1,7 @@
 import httpx
 from typing import List, Dict, Any
 from app.core.config import settings
+from app.core.time import parse_utc
 from app.services.project_service import ProjectService
 from sqlalchemy.orm import Session
 import json
@@ -58,8 +59,8 @@ class GitHubService:
             "forks": repo_data.get("forks_count", 0),
             "topics": topics or [],
             "is_featured": self._is_featured_repo(repo_data, topics or []),
-            "created_at": repo_data.get("created_at"),
-            "updated_at": repo_data.get("updated_at"),
+            "created_at": parse_utc(repo_data.get("created_at")),
+            "updated_at": parse_utc(repo_data.get("updated_at")),
         }
 
     def _is_featured_repo(self, repo_data: Dict[str, Any], topics: List[str]) -> bool:

--- a/apps/api/app/services/linkedin.py
+++ b/apps/api/app/services/linkedin.py
@@ -13,6 +13,8 @@ import logging
 from datetime import datetime, timezone, timedelta
 from typing import Dict, List, Optional, Any
 import requests
+
+from app.core.time import utc_now
 from app.schemas.cv import (
     CVProfile,
     PersonalInfo,
@@ -57,7 +59,7 @@ class LinkedInService:
         if not self.last_sync:
             return True
 
-        return datetime.now(timezone.utc) - self.last_sync > self.sync_interval
+        return utc_now() - self.last_sync > self.sync_interval
 
     async def sync_profile_data(
         self, force_refresh: bool = False
@@ -81,8 +83,6 @@ class LinkedInService:
 
         try:
             logger.info("Starting LinkedIn profile sync")
-
-            # Fetch profile data
             profile_data = await self._fetch_profile_data()
             if not profile_data:
                 logger.error("Failed to fetch LinkedIn profile data")
@@ -94,8 +94,7 @@ class LinkedInService:
                 logger.error("Failed to transform LinkedIn data to CV profile")
                 return None
 
-            # Update last sync time
-            self.last_sync = datetime.now(timezone.utc)
+            self.last_sync = utc_now()
 
             logger.info("LinkedIn profile sync completed successfully")
             return cv_profile
@@ -210,7 +209,7 @@ class LinkedInService:
                 skills=skills,
                 certifications=certifications,
                 languages=languages,
-                last_updated=datetime.now(timezone.utc),
+                last_updated=utc_now(),
                 linkedin_url=personal_info.linkedin_url,
                 version="1.0",
             )

--- a/apps/api/app/services/project_service.py
+++ b/apps/api/app/services/project_service.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 import json
 from typing import List, Optional
 
 from sqlalchemy import desc
 from sqlalchemy.orm import Session
 
+from app.core.time import utc_now
 from app.models.database import Project
 
 
@@ -56,7 +56,7 @@ class ProjectService:
                         setattr(existing_project, key, json.dumps(value))
                     else:
                         setattr(existing_project, key, value)
-            existing_project.updated_at = datetime.utcnow()
+            existing_project.updated_at = utc_now()
             db.commit()
             return existing_project
         else:

--- a/apps/api/app/services/scoring.py
+++ b/apps/api/app/services/scoring.py
@@ -7,8 +7,9 @@ This service implements a sophisticated scoring algorithm that considers:
 - Recency (20%): Recent updates and active development
 """
 
-from datetime import datetime, timezone
 from typing import Dict, List
+
+from app.core.time import as_utc, utc_now
 from app.models.database import Project as DBProject
 
 
@@ -262,15 +263,9 @@ class ProjectScoringService:
         if not project.updated_at:
             return 0.0
 
-        # Calculate days since last update
-        now = datetime.now(timezone.utc)
-
-        # Handle both naive and aware datetimes
-        if project.updated_at.tzinfo is None:
-            # If database datetime is naive, assume it's UTC
-            updated_at = project.updated_at.replace(tzinfo=timezone.utc)
-        else:
-            updated_at = project.updated_at
+        # UTC clock and legacy-naive normalization share one contract.
+        now = utc_now()
+        updated_at = as_utc(project.updated_at)
 
         days_since_update = (now - updated_at).days
 

--- a/apps/api/app/services/showcase_service.py
+++ b/apps/api/app/services/showcase_service.py
@@ -11,6 +11,8 @@ This service manages showcase information for key projects:
 import logging
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional
+
+from app.core.time import utc_now
 from app.schemas.project import (
     ProjectShowcase,
     ShowcaseProject,
@@ -28,7 +30,7 @@ class ShowcaseService:
     def __init__(self):
         """Initialize the showcase service with key projects."""
         self.showcase_projects = self._initialize_showcase_projects()
-        self.last_updated = datetime.now(timezone.utc)
+        self.last_updated = utc_now()
 
     def _initialize_showcase_projects(self) -> List[ProjectShowcase]:
         """Initialize showcase projects with detailed information."""
@@ -339,7 +341,7 @@ class ShowcaseService:
             if project.project_type == project_type:
                 project.stars = stars
                 project.forks = forks
-                project.last_updated = datetime.now(timezone.utc)
+                project.last_updated = utc_now()
                 logger.info(
                     f"Updated metrics for {project.name}: {stars} stars, {forks} forks"
                 )

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -18,19 +18,21 @@ dependencies = [
     "passlib[bcrypt]==1.7.4",
     "python-dotenv==1.2.2",
     "requests==2.34.2",
-    "idna==3.15",
+    "idna==3.18",
     "Mako==1.3.12",
     "aiohttp==3.14.3",
+    "httpx==0.28.1",
 ]
 
 [project.optional-dependencies]
 dev = [
     "pytest==9.0.3",
     "pytest-asyncio==1.4.0",
-    "httpx==0.28.1",
+    "httpx2==2.9.1",
     "black==26.3.1",
     "ruff==0.12.9",
     "Pygments==2.20.0",
+    "types-requests==2.32.4.20250809",
     "mypy==1.17.1",
 ]
 

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -6,3 +6,6 @@ python_classes = Test*
 python_functions = test_*
 addopts = -v --tb=short
 asyncio_mode = auto
+filterwarnings =
+    error::DeprecationWarning
+    error::starlette.exceptions.StarletteDeprecationWarning

--- a/apps/api/requirements-dev.txt
+++ b/apps/api/requirements-dev.txt
@@ -1,8 +1,9 @@
 -r requirements.txt
 pytest==9.0.3
 pytest-asyncio==1.4.0
-httpx==0.28.1
+httpx2==2.9.1
 black==26.3.1
 ruff==0.12.9
+mypy==1.17.1
 Pygments==2.20.0
 types-requests==2.32.4.20250809

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -10,7 +10,7 @@ python-multipart==0.0.32
 passlib[bcrypt]==1.7.4
 python-dotenv==1.2.2
 requests==2.34.2
-idna==3.15
+idna==3.18
 Mako==1.3.12
 aiohttp==3.14.3
 httpx==0.28.1

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from datetime import datetime
 import json
 
+from app.core.time import utc_now
 from app.models.database import (
     Base,
     Project,  # noqa: F401
@@ -46,8 +46,8 @@ def sample_project_data():
         "forks": 5,
         "topics": json.dumps(["python", "test"]),
         "is_featured": True,
-        "created_at": datetime.utcnow(),
-        "updated_at": datetime.utcnow(),
+        "created_at": utc_now(),
+        "updated_at": utc_now(),
     }
 
 

--- a/apps/api/tests/test_datetime_contracts.py
+++ b/apps/api/tests/test_datetime_contracts.py
@@ -1,0 +1,149 @@
+"""UTC timestamp and deprecation contract regressions for the optional API."""
+
+import ast
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, cast
+
+from sqlalchemy import text
+
+from app.models.database import CVDownload, ChatMessage, ChatSession, Contact, Project
+from app.schemas.cv import CVProfile, Skills
+
+API_ROOT = Path(__file__).resolve().parents[1]
+TIMESTAMP_COLUMNS = (
+    (Project, "created_at"),
+    (Project, "updated_at"),
+    (Contact, "created_at"),
+    (ChatSession, "created_at"),
+    (ChatSession, "last_activity"),
+    (ChatMessage, "timestamp"),
+    (CVDownload, "download_date"),
+)
+
+
+def _assert_aware_utc(value: datetime) -> None:
+    assert value.tzinfo is not None
+    offset = value.utcoffset()
+    assert offset is not None
+    assert offset.total_seconds() == 0
+
+
+def test_api_python_avoids_deprecated_datetime_and_pydantic_apis() -> None:
+    violations: list[str] = []
+    for root in (API_ROOT / "app", API_ROOT / "tests"):
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Attribute) and node.attr in {
+                    "utcnow",
+                    "__fields__",
+                }:
+                    violations.append(
+                        f"{path.relative_to(API_ROOT)}:{node.lineno}:{node.attr}"
+                    )
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "datetime"
+                    and node.func.attr == "now"
+                    and path != API_ROOT / "app/core/time.py"
+                ):
+                    violations.append(
+                        f"{path.relative_to(API_ROOT)}:{node.lineno}:direct datetime.now()"
+                    )
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "dict"
+                ):
+                    violations.append(
+                        f"{path.relative_to(API_ROOT)}:{node.lineno}:deprecated .dict()"
+                    )
+
+    assert violations == []
+
+
+def test_database_timestamp_columns_declare_timezone_support() -> None:
+    for model, attribute in TIMESTAMP_COLUMNS:
+        column = getattr(model, attribute).property.columns[0]
+        column_type = column.type
+        timezone = getattr(column_type, "timezone", None)
+        if timezone is None:
+            timezone = getattr(getattr(column_type, "impl", None), "timezone", None)
+        assert timezone is True, f"{model.__name__}.{attribute} must preserve timezone"
+
+
+def test_database_timestamp_round_trips_are_aware_utc(db_session) -> None:
+    records = (
+        (
+            Project(github_id=1, name="clock", url="https://example.com"),
+            ("created_at", "updated_at"),
+        ),
+        (
+            Contact(name="Clock", email="clock@example.com", message="test"),
+            ("created_at",),
+        ),
+        (ChatSession(session_id="clock"), ("created_at", "last_activity")),
+        (ChatMessage(role="user", content="clock"), ("timestamp",)),
+        (CVDownload(), ("download_date",)),
+    )
+
+    for record, attributes in records:
+        db_session.add(record)
+        db_session.commit()
+        db_session.refresh(record)
+        for attribute in attributes:
+            _assert_aware_utc(getattr(record, attribute))
+
+
+def test_legacy_naive_database_timestamp_is_read_as_utc(db_session) -> None:
+    db_session.execute(
+        text(
+            "INSERT INTO contacts "
+            "(name, email, message, created_at, is_read) "
+            "VALUES ('Legacy', 'legacy@example.com', 'test', "
+            "'2024-01-02 03:04:05', 0)"
+        )
+    )
+    db_session.commit()
+
+    contact = (
+        db_session.query(Contact).filter(Contact.email == "legacy@example.com").one()
+    )
+    _assert_aware_utc(contact.created_at)
+    assert contact.created_at.isoformat() == "2024-01-02T03:04:05+00:00"
+
+
+def test_cv_default_and_legacy_timestamp_are_utc_aware() -> None:
+    field = CVProfile.model_fields["last_updated"]
+    factory = cast(Callable[[], datetime], field.default_factory)
+    _assert_aware_utc(factory())
+
+    profile = CVProfile.model_validate(
+        {
+            "personal_info": {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": "test@example.com",
+                "location": "Santiago, Chile",
+                "linkedin_url": "https://www.linkedin.com/in/test",
+                "summary": "Test profile",
+            },
+            "skills": {},
+            "last_updated": datetime(2024, 1, 1),
+            "linkedin_url": "https://www.linkedin.com/in/test",
+        }
+    )
+    _assert_aware_utc(profile.last_updated)
+
+
+def test_pydantic_helpers_are_warning_free() -> None:
+    assert Skills().get_all_skills() == []
+
+
+def test_starlette_testclient_uses_httpx2() -> None:
+    import starlette.testclient as testclient
+
+    assert testclient.httpx.__name__ == "httpx2"

--- a/apps/api/tests/test_github_service.py
+++ b/apps/api/tests/test_github_service.py
@@ -1,4 +1,7 @@
+from datetime import UTC
+
 from app.services.github_service import GitHubService
+from app.services.project_service import ProjectService
 
 
 class TestGitHubService:
@@ -24,8 +27,8 @@ class TestGitHubService:
         topics = []
         assert service._is_featured_repo(repo_data, topics) is False
 
-    def test_repo_data_transformation(self):
-        """Test repository data transformation."""
+    def test_repo_data_transformation(self, db_session):
+        """GitHub timestamps become persistable aware UTC values."""
         service = GitHubService()
 
         repo_data = {
@@ -47,3 +50,9 @@ class TestGitHubService:
         assert transformed["name"] == "test-project"
         assert transformed["topics"] == ["python", "test"]
         assert transformed["is_featured"] is True
+        assert transformed["created_at"].tzinfo is UTC
+        assert transformed["updated_at"].tzinfo is UTC
+
+        project = ProjectService.create_or_update_project(db_session, transformed)
+        assert project.created_at.tzinfo is UTC
+        assert project.updated_at.tzinfo is UTC

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -37,6 +37,15 @@ Source of truth: `docs/ARCHITECTURE.yaml`. Tracking: [Project #24](https://githu
 - Data posture: Static-first public content adapter with curated/redacted React-folio resume JSON; optional API adapters remain separate from presentation and must record source/freshness/evidence before use.
 - Consolidation evidence: `docs/REACT_FOLIO_CONSOLIDATION.md` records the one-way React-folio to main_website migration, phone redaction, static export posture, and explicit source-repository retention.
 
+### Executive summary: optional API time and HTTP clients
+
+- **UTC timestamps:** `apps/api/app/core/time.py::utc_now` is the single clock factory for generated API timestamps. It returns aware UTC values; ORM timestamp columns declare `DateTime(timezone=True)`.
+- **Legacy data:** the repository has Alembic scaffolding but no revision baseline. `UTCDateTime` therefore interprets existing naive timestamps as UTC and restores aware UTC values after database reads rather than claiming an unexecuted production migration. PostgreSQL preserves timezone semantics directly; SQLite may discard offsets internally, but the application boundary restores them before consumers or serializers observe the value.
+- **HTTP ownership:** `httpx` remains the runtime client used by the GitHub adapter. `httpx2` is development-only and backs Starlette/FastAPI `TestClient`, as recommended by current Starlette documentation.
+- **Fail-closed verification:** API tests promote Python and Starlette deprecations to errors. `apps/api/tests/test_datetime_contracts.py` forbids `datetime.utcnow`, verifies timezone-aware ORM declarations and CV defaults, and proves TestClient selected HTTPX2 rather than its deprecated HTTPX fallback.
+
+This split avoids a risky application-wide HTTP-client migration while removing the deprecation path actually exercised by tests.
+
 ### Extension and exception discipline
 
 Probable extensions must cross named ports/capability registries rather than adding sibling modules indefinitely. Every exception is exact, risk-bearing, no-growth, and has a refactoring trigger. Generated/vendor/migration/resource paths are declared explicitly; they do not silently weaken runtime rules.

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -41,6 +41,17 @@
         ]
       }
     ],
+    "time_contract": {
+      "canonical_zone": "UTC",
+      "generation": "apps/api/app/core/time.py::utc_now returns timezone-aware datetime values",
+      "persistence": "SQLAlchemy UTCDateTime stores normalized UTC and restores timezone metadata on reads, including SQLite and legacy naive rows",
+      "legacy_read_compatibility": "Existing naive database timestamps are interpreted as UTC by the application boundary until an explicit Alembic baseline exists",
+      "forbidden": "datetime.utcnow and newly generated naive timestamps",
+      "fitness_tests": [
+        "apps/api/tests/test_datetime_contracts.py",
+        "apps/api/pytest.ini deprecation warnings as errors"
+      ]
+    },
     "extension_points": [
       "typed public APIs",
       "deterministic CLI/contracts",
@@ -211,6 +222,29 @@
           ".github/workflows/ai-hierarchy-policy.yml",
           "scripts/selftest_ai_hierarchy_policy.py"
         ]
+      },
+      {
+        "capability": "HTTP clients and ASGI test transport",
+        "selected": [
+          "HTTPX 0.28.1 for the runtime GitHub adapter",
+          "HTTPX2 2.9.1 for the development-only Starlette TestClient backend",
+          "IDNA 3.18 shared security-compatible domain processing"
+        ],
+        "alternatives": [
+          "Deprecated Starlette fallback to plain HTTPX",
+          "Requests for ASGI in-process testing"
+        ],
+        "evidence": "https://starlette.dev/testclient and https://pypi.org/project/httpx2/2.9.1/",
+        "adapter_boundary": "HTTPX remains owned by apps/api/app/services/github_service.py; HTTPX2 is restricted to apps/api development tests.",
+        "custom_code_reason": "No custom HTTP transport; maintained clients own runtime and in-process test semantics.",
+        "maintenance_evidence": "https://github.com/pydantic/httpx2/releases/tag/v2.9.1",
+        "api_stability_evidence": "https://httpx2.pydantic.dev/",
+        "license_evidence": "https://raw.githubusercontent.com/pydantic/httpx2/v2.9.1/LICENSE.md",
+        "api_license_evidence": "https://raw.githubusercontent.com/pydantic/httpx2/v2.9.1/LICENSE.md",
+        "oracle_or_reference_tests": [
+          "apps/api/tests/test_datetime_contracts.py::test_starlette_testclient_uses_httpx2",
+          "tests/architecture/test_dependency_security_floors.py"
+        ]
       }
     ]
   },
@@ -267,6 +301,7 @@
     "commands": {
       "setup": "pnpm install --frozen-lockfile && (cd apps/api && python -m pip install -e .[dev])",
       "test": "pnpm test",
+      "api_test": "cd apps/api && python -m pytest",
       "lint": "pnpm run lint",
       "architecture": "python scripts/check_portfolio_architecture.py"
     },
@@ -297,6 +332,7 @@
       "explicit external/social adapters with credential isolation and freshness metadata"
     ],
     "flow": "React-folio resume/source registry -> phone-redacted checked-in copy with intentionally public email -> typed curated public content -> static Next.js pages; optional dynamic adapters remain separately validated.",
+    "timestamp_semantics": "Optional API timestamps are generated as timezone-aware UTC values and declared timezone-aware in SQLAlchemy metadata. Existing naive values remain readable as UTC until a real Alembic baseline and deployment-specific migration exist.",
     "storage_and_replay": "Immutable raw/content-addressed inputs; canonical typed products; idempotent replay by source identity and effective/vintage time where applicable.",
     "quality_and_lineage": "Validate schema, grain, units, classification, lineage, freshness, licence, and content identity before consumption; fail closed on missing evidence."
   },

--- a/tests/architecture/test_dependency_security_floors.py
+++ b/tests/architecture/test_dependency_security_floors.py
@@ -13,8 +13,8 @@ def test_python_security_floors_are_synchronized_across_manifests() -> None:
     dev_requirements = (API / "requirements-dev.txt").read_text(encoding="utf-8")
     pyproject = tomllib.loads((API / "pyproject.toml").read_text(encoding="utf-8"))
 
-    runtime_floors = {"idna==3.15", "Mako==1.3.12"}
-    dev_floors = {"Pygments==2.20.0"}
+    runtime_floors = {"idna==3.18", "Mako==1.3.12", "httpx==0.28.1"}
+    dev_floors = {"Pygments==2.20.0", "httpx2==2.9.1"}
     project_runtime = set(pyproject["project"]["dependencies"])
     project_dev = set(pyproject["project"]["optional-dependencies"]["dev"])
 
@@ -22,6 +22,28 @@ def test_python_security_floors_are_synchronized_across_manifests() -> None:
     assert runtime_floors <= project_runtime
     assert dev_floors <= set(dev_requirements.splitlines())
     assert dev_floors <= project_dev
+
+    runtime_manifest = {
+        line
+        for line in runtime_requirements.splitlines()
+        if line and not line.startswith("#")
+    }
+    dev_manifest = {
+        line
+        for line in dev_requirements.splitlines()
+        if line and not line.startswith(("#", "-r "))
+    }
+    assert runtime_manifest == project_runtime
+    assert dev_manifest == project_dev
+
+
+def test_ci_audits_runtime_and_development_python_dependencies() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "pip-audit -r apps/api/requirements.txt" in workflow
+    assert "pip-audit -r apps/api/requirements-dev.txt" in workflow
 
 
 def test_postcss_security_floor_is_owned_by_override_and_lock() -> None:


### PR DESCRIPTION
## Summary

- centralize generated timestamps through one aware-UTC clock;
- normalize database writes and reads with `UTCDateTime`, including SQLite and legacy naïve rows;
- parse GitHub ISO timestamps before persistence and normalize CV inputs;
- remove exercised Pydantic v2 deprecations and fail API tests on future deprecation warnings;
- use HTTPX2 for Starlette TestClient while preserving HTTPX as the runtime GitHub client;
- synchronize runtime/development manifests, IDNA 3.18, and CI audits;
- add executable timestamp, manifest, and CI fitness tests;
- document UTC persistence, legacy compatibility, and HTTP-client ownership with verified maintenance/license evidence.

Closes #100

## Verification

- `uv run pytest -q`: 20 passed, deprecations configured as errors
- `uv run ruff check .`: passed
- `uv run ruff format --check .`: 39 files formatted
- `uv run mypy .`: 39 source files clean
- runtime `pip-audit`: no known vulnerabilities
- development `pip-audit`: no known vulnerabilities
- architecture tests: 13 passed
- portfolio architecture: passed, including legacy no-growth ratchets
- AI/hierarchy policy and adversarial self-tests: passed
- Zizmor 1.28.0 offline medium+: no findings
- Markdown link audit: 24 files, zero findings
- uncached monorepo test/lint/typecheck/build: passed
- `git diff --check`: passed

## Independent review

Two adversarial review rounds identified and drove fixes for:

- SQLite/legacy timezone restoration;
- GitHub ISO-string persistence;
- latent Pydantic v2 deprecations;
- runtime HTTPX ownership;
- broken dependency-evidence URLs;
- CI development-dependency audit coverage;
- single-clock truthfulness;
- exact dev-manifest parity.

Final blocker-only review: PASS.

## Scope boundary

Pre-existing pnpm lifecycle, Husky, Next.js/Node deprecation, and placeholder API-build warnings are tracked separately by #101. No lifecycle scripts were approved or suppressed in this PR.
