### PR TITLE
Harden monorepo runtime and dependency build policy

### DIFF
--- a/.github/workflows/ai-hierarchy-policy.yml
+++ b/.github/workflows/ai-hierarchy-policy.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Install pinned governance tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,26 +14,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          node-version: 22
+          version: 10.34.5
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.19.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Verify dependency build policy
+        run: pnpm run check:dependency-build-policy
 
       - name: Lint frontend
         run: pnpm --filter web lint
@@ -66,26 +71,31 @@ jobs:
     needs: quality-checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          node-version: 22
+          version: 10.34.5
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.19.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Verify dependency build policy
+        run: pnpm run check:dependency-build-policy
 
       - name: Run frontend tests
         run: pnpm --filter web test
@@ -106,12 +116,12 @@ jobs:
     needs: quality-checks
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Machine-owned formats: preserve JSON-subset architecture and pnpm canonical lock output.
+docs/ARCHITECTURE.yaml
+pnpm-lock.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - `docs/ARCHITECTURE.md` — rationale and extension guidance
 
 <!-- PORTFOLIO-CONSTITUTION:START -->
+
 ## Portfolio engineering constitution
 
 This repository follows [Portfolio Project #24](https://github.com/users/googa27/projects/24) and [main_website rollout issue](https://github.com/googa27/main_website/issues/84). A repository-specific, evidence-backed exception in `docs/ARCHITECTURE.yaml` may specialize a rule; undocumented drift is not an exception.
@@ -54,13 +55,19 @@ After the dependency route is sound, apply SOLID, DRY knowledge ownership, suita
 - `__init__.py` is a compatibility/public facade only: imports, re-exports, `__all__`, metadata, and bounded lazy hooks. Domain classes and business functions belong in cohesive modules.
 - Severe branch concentration is a review trigger, not a command to redistribute files. Fix it only when dependency, churn, ownership, or comprehension evidence shows a bad boundary.
 
-
 ### GitHub Actions supply-chain controls
 
 - Pin every third-party action to a full-length commit SHA; keep the human-readable release in a comment.
 - Declare least-privilege workflow `permissions`; read-only `contents` is the default.
 - Set `persist-credentials: false` on checkout and provide narrowly scoped credentials only to the step that needs mutation.
 - Validate workflow changes with `python scripts/selftest_ai_hierarchy_policy.py`, `pinact run --fix=false --no-api`, and `zizmor --offline --min-severity medium .`.
+
+### Node tooling and dependency lifecycle controls
+
+- `packageManager` pins pnpm 10.34.5; `devEngines.runtime` pins managed Node 24.19.0 for project scripts. Do not bypass the managed runtime with a newer host Node.
+- `@tailwindcss/oxide@4.1.12` and `unrs-resolver@1.11.1` lifecycle scripts are deliberately denied after exact script review. The locked optional native bindings load and the full lint/build matrix passes without network download fallbacks.
+- Run `pnpm run check:dependency-build-policy` after every workspace install. Any lock-version, deny-list, reviewed script-byte, support-package, or pending-build drift fails until the exact new lifecycle path is reviewed.
+- The optional FastAPI package has no build artifact and therefore no placeholder `build` task; root `pnpm build` targets only artifact-producing workspaces.
 
 ### Data and core-repository boundaries
 
@@ -77,12 +84,16 @@ React-folio consolidation evidence lives in `docs/REACT_FOLIO_CONSOLIDATION.md`.
 
 ### Exact commands
 
-- Setup: `pnpm install --frozen-lockfile && (cd apps/api && python -m pip install -e .[dev])`
+- Setup: `corepack enable && pnpm install --frozen-lockfile && pnpm run check:dependency-build-policy && (cd apps/api && python -m pip install -e .[dev])`
 - Tests: `pnpm test`
 - Lint/format: `pnpm run lint`
+- Build: `pnpm run build`
+- Typecheck: `pnpm run typecheck`
+- Dependency build policy: `pnpm run check:dependency-build-policy`
 - Portfolio architecture: `python scripts/check_portfolio_architecture.py`
 - Governance setup: `python3 -m pip install -r requirements-architecture.txt`
 - AI/hierarchy policy: `python3 scripts/check_ai_hierarchy_policy.py`
 
 If a command is declared unavailable, the activation trigger and replacement command belong in `docs/ARCHITECTURE.yaml`; do not fabricate successful output.
+
 <!-- PORTFOLIO-CONSTITUTION:END -->

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Portfolio monorepo for Cristóbal Cortinez Duhalde, split into a Next.js fronten
 
 ## Current status at a glance
 
-| Area | Implemented today | Caveat |
-|---|---|---|
-| Web app | Next.js 15 App Router with Home, About, Projects, Contact pages | Some content is static in page files. |
-| API app | FastAPI app with health, projects, showcase, contact, AI, and CV routers | Several routes depend on database, SMTP, OpenAI/Ollama, or local static data. |
-| Monorepo tooling | pnpm workspaces + Turborepo | `pnpm format` writes changes; use package-level `--check` commands for CI-style verification. |
-| Project data | SQLAlchemy project/contact models, GitHub sync service, hardcoded showcase service | Frontend `Project` interface does not match the `/api/projects` response shape yet. |
-| CV data | `apps/api/app/static/cv/cv_profile.json` served through CV service endpoints | LinkedIn sync/export features are scaffolded, not a verified production integration. |
-| Deployment | Dockerfiles and deployment-oriented docs exist | No production host/URL is verified in this README. |
-| License | API package metadata says MIT | No root `LICENSE` file is tracked; do not advertise root MIT licensing until added. |
+| Area             | Implemented today                                                                  | Caveat                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Web app          | Next.js 16.2.11 App Router with Home, About, Projects, Contact pages               | Some content is static in page files.                                                                                   |
+| API app          | FastAPI app with health, projects, showcase, contact, AI, and CV routers           | Several routes depend on database, SMTP, OpenAI/Ollama, or local static data.                                           |
+| Monorepo tooling | pnpm 10.34.5 workspaces + Turborepo, with managed Node 24.19.0                     | Native dependency fallback scripts are explicitly denied because locked optional binaries pass load/build verification. |
+| Project data     | SQLAlchemy project/contact models, GitHub sync service, hardcoded showcase service | Frontend `Project` interface does not match the `/api/projects` response shape yet.                                     |
+| CV data          | `apps/api/app/static/cv/cv_profile.json` served through CV service endpoints       | LinkedIn sync/export features are scaffolded, not a verified production integration.                                    |
+| Deployment       | Dockerfiles and deployment-oriented docs exist                                     | No production host/URL is verified in this README.                                                                      |
+| License          | API package metadata says MIT                                                      | No root `LICENSE` file is tracked; do not advertise root MIT licensing until added.                                     |
 
 ## Architecture
 
@@ -49,7 +49,7 @@ Important caveats:
 
 ### Web (`apps/web`)
 
-- Next.js 15.4.x App Router.
+- Next.js 16.2.11 App Router.
 - React 19 and TypeScript.
 - Tailwind CSS 4 via PostCSS.
 - Pages:
@@ -64,14 +64,14 @@ Important caveats:
 
 FastAPI app mounted in `apps/api/app/main.py`:
 
-| Router | Prefix | Implemented routes include |
-|---|---|---|
-| `health` | `/api` | `/health`, `/health/db` |
-| `projects` | `/api` | `/projects`, `/projects/featured`, `/projects/sync`, `/projects/{id}`, `/projects/{id}/score`, `/projects/showcase*` |
-| `contact` | `/api` | `POST /contact`, contact lookup/read admin-style helpers |
-| `ai` | `/api` | `/ai/status`, `POST /chat`, `POST /predict`, `POST /visualize` |
-| `cv` | `/api` | `/cv/profile`, `/cv/export*`, `/cv/status`, `/cv/formats`, `/cv/linkedin/status`, `/cv/download` |
-| static files | `/static` | Serves `apps/api/app/static` |
+| Router       | Prefix    | Implemented routes include                                                                                           |
+| ------------ | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| `health`     | `/api`    | `/health`, `/health/db`                                                                                              |
+| `projects`   | `/api`    | `/projects`, `/projects/featured`, `/projects/sync`, `/projects/{id}`, `/projects/{id}/score`, `/projects/showcase*` |
+| `contact`    | `/api`    | `POST /contact`, contact lookup/read admin-style helpers                                                             |
+| `ai`         | `/api`    | `/ai/status`, `POST /chat`, `POST /predict`, `POST /visualize`                                                       |
+| `cv`         | `/api`    | `/cv/profile`, `/cv/export*`, `/cv/status`, `/cv/formats`, `/cv/linkedin/status`, `/cv/download`                     |
+| static files | `/static` | Serves `apps/api/app/static`                                                                                         |
 
 ### Data sources
 
@@ -114,14 +114,17 @@ packages/
 
 Prerequisites:
 
-- Node.js compatible with the lockfile and `packageManager` (`pnpm@10.14.0`).
+- Corepack or pnpm bootstrap capable of honoring `packageManager` (`pnpm@10.34.5`).
+- Network access on first install so pnpm can cache the managed development runtime (`node@24.19.0`); subsequent scripts use that runtime even when the host Node is newer.
 - Python 3.12+ for `apps/api`.
 - PostgreSQL if you want database-backed project/contact routes instead of import/build smoke checks.
 
 Install frontend/monorepo dependencies from the lockfile:
 
 ```bash
+corepack enable
 pnpm install --frozen-lockfile
+pnpm run check:dependency-build-policy
 ```
 
 Create frontend environment file:
@@ -157,10 +160,11 @@ From the repo root:
 
 ```bash
 pnpm dev          # Turborepo dev across workspaces
-pnpm build        # Build workspaces
+pnpm build        # Build artifact-producing workspaces (currently the Next.js web app)
 pnpm lint         # Lint workspaces
 pnpm typecheck    # Type-check workspaces
 pnpm test         # Run workspace tests; web currently echoes "No tests yet"
+pnpm run check:dependency-build-policy  # Verify denied versions, script hashes, and pending-build state
 ```
 
 Individual apps:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,8 +10,7 @@
     "format": "black .",
     "db:setup": "python scripts/init_db.py",
     "db:migrate": "alembic upgrade head",
-    "db:revision": "alembic revision --autogenerate -m",
-    "build": "echo 'FastAPI app built successfully'"
+    "db:revision": "alembic revision --autogenerate -m"
   },
   "engines": {
     "python": ">=3.12"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "test": "echo 'No tests yet'"
   },
   "dependencies": {
-    "next": "16.2.10",
+    "next": "16.2.11",
     "react": "19.2.7",
     "react-dom": "19.2.7"
   },
@@ -24,7 +24,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9.39.5",
-    "eslint-config-next": "16.2.10",
+    "eslint-config-next": "16.2.11",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,6 +46,21 @@ Source of truth: `docs/ARCHITECTURE.yaml`. Tracking: [Project #24](https://githu
 
 This split avoids a risky application-wide HTTP-client migration while removing the deprecation path actually exercised by tests.
 
+### Executive summary: monorepo tooling and lifecycle policy
+
+| Boundary          | Decision                                                                                                 | Why                                                                                                                                                                    | Executable evidence                                   |
+| ----------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Package manager   | Pin `pnpm@10.34.5`                                                                                       | Current pnpm 10 maintenance release while preserving the existing lockfile major                                                                                       | `packageManager`; `test_node_tooling_contract.py`     |
+| Script runtime    | Let pnpm download and use `node@24.19.0` through `devEngines.runtime`                                    | Tailwind's current Node adapter emits `DEP0205` under Node 26; Node 24 is a maintained LTS and is warning-free for this build                                          | `pnpm install`; uncached `pnpm build`                 |
+| Oxide fallback    | Deny `@tailwindcss/oxide@4.1.12` postinstall                                                             | The reviewed script performs a registry download and archive extraction only when the locked optional binary is missing; direct load and production build already pass | `pnpm.ignoredBuiltDependencies`; lock/version checker |
+| Resolver fallback | Deny `unrs-resolver@1.11.1` postinstall                                                                  | The reviewed checker can invoke npm or download a native binding; the locked optional binding already loads and lint/build pass                                        | `pnpm.ignoredBuiltDependencies`; lock/version checker |
+| API build         | Remove the echo-only package build task                                                                  | FastAPI is a runtime service and produces no build artifact; claiming a successful build created a Turborepo cache warning and false evidence                          | absence asserted by architecture test                 |
+| GitHub Actions    | Full-SHA pins for checkout v7.0.1, setup-node v7.0.0, setup-python v7.0.0, and pnpm/action-setup v6.0.10 | These reviewed releases use Node 24 internally and eliminate GitHub's Node 20 action-runtime annotation                                                                | architecture test, Pinact, Zizmor, native CI          |
+
+No lifecycle script is silently approved. Future lock changes remain denied by pnpm and fail `pnpm run check:dependency-build-policy` until the exact new version, package manifest, lifecycle entrypoint, support-package implementation, and pending-build state are reviewed.
+
+The Node 26 warning is tracked upstream at https://github.com/tailwindlabs/tailwindcss/issues/19893. Remove the managed Node 24 constraint only after a stable Tailwind release replaces `module.register()` and an uncached Node 26 build is warning-free; do not suppress `DEP0205`.
+
 ### Extension and exception discipline
 
 Probable extensions must cross named ports/capability registries rather than adding sibling modules indefinitely. Every exception is exact, risk-bearing, no-growth, and has a refactoring trigger. Generated/vendor/migration/resource paths are declared explicitly; they do not silently weaken runtime rules.

--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -52,6 +52,53 @@
         "apps/api/pytest.ini deprecation warnings as errors"
       ]
     },
+    "dependency_lifecycle_policy": {
+      "package_manager": "pnpm@10.34.5",
+      "denied_packages": {
+        "@tailwindcss/oxide": {
+          "version": "4.1.12",
+          "decision": "deny",
+          "lifecycle_command": "node ./scripts/install.js",
+          "manifest_sha256": "19e31a0bc5fa826d5f4c1a73fa2d7e821e3ed826f86d28987618bc18c0a3a656",
+          "script_sha256": "df8750369bdc91787de5baec99eaaf27b7d8d2952acb25cf1a0b0aa511185b2a"
+        },
+        "unrs-resolver": {
+          "version": "1.11.1",
+          "decision": "deny",
+          "lifecycle_command": "napi-postinstall unrs-resolver 1.11.1 check",
+          "manifest_sha256": "0510c5611b2c4436d12364dff5ddd0f227dacd174cadd62141b226bce1fa4b19",
+          "script_sha256": "2d79f5b3ee7566309a587c267ab8363881f5ebe97a728b0271fb530569b1f356",
+          "support_package": {
+            "name": "napi-postinstall",
+            "version": "0.3.3",
+            "manifest_sha256": "94d75d361fd158062dd3888ca0bd3abc90d67ef0f5f746d4b7b0de9065a384bd",
+            "lib_files": [
+              "lib/cli.js",
+              "lib/constants.js",
+              "lib/fallback.js",
+              "lib/helpers.js",
+              "lib/index.js",
+              "lib/target.js",
+              "lib/types.js"
+            ],
+            "lib_tree_sha256": "f2b5f747776727b0bf13220d49407cd0523d180842a09df3bc2e2f2e9116e3d8",
+            "cli_sha256": "2d79f5b3ee7566309a587c267ab8363881f5ebe97a728b0271fb530569b1f356"
+          }
+        }
+      },
+      "rationale": {
+        "@tailwindcss/oxide": "The postinstall performs an unneeded registry download and archive extraction fallback when the locked optional binary is absent; direct load and production build pass while denied.",
+        "unrs-resolver": "The postinstall can invoke npm or download a native binary fallback; the locked optional binding loads and lint/build pass while denied."
+      },
+      "verification_command": "pnpm run check:dependency-build-policy",
+      "policy_source": "https://pnpm.io/settings#ignoredbuiltdependencies"
+    },
+    "node_runtime_policy": {
+      "managed_runtime": "node@24.19.0",
+      "reason": "Tailwind CSS 4 emits Node DEP0205 under Node 26",
+      "upstream_issue": "https://github.com/tailwindlabs/tailwindcss/issues/19893",
+      "removal_trigger": "upgrade after a stable Tailwind release replaces module.register and the Node 26 strict build is warning-free"
+    },
     "extension_points": [
       "typed public APIs",
       "deterministic CLI/contracts",
@@ -299,10 +346,13 @@
       "architecture"
     ],
     "commands": {
-      "setup": "pnpm install --frozen-lockfile && (cd apps/api && python -m pip install -e .[dev])",
+      "setup": "corepack enable && pnpm install --frozen-lockfile && pnpm run check:dependency-build-policy && (cd apps/api && python -m pip install -e .[dev])",
       "test": "pnpm test",
       "api_test": "cd apps/api && python -m pytest",
       "lint": "pnpm run lint",
+      "typecheck": "pnpm run typecheck",
+      "build": "pnpm run build",
+      "dependency_build_policy": "pnpm run check:dependency-build-policy",
       "architecture": "python scripts/check_portfolio_architecture.py"
     },
     "ci_workflow": ".github/workflows/portfolio-architecture.yml",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "format": "turbo format",
     "typecheck": "turbo typecheck",
     "test": "turbo test",
+    "check:dependency-build-policy": "node scripts/check-dependency-build-policy.mjs",
     "clean": "rm -rf .turbo apps/*/.turbo packages/*/.turbo apps/web/out apps/web/.next",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "devDependencies": {
     "@repo/config": "workspace:*",
@@ -26,6 +27,10 @@
     ]
   },
   "pnpm": {
+    "ignoredBuiltDependencies": [
+      "@tailwindcss/oxide",
+      "unrs-resolver"
+    ],
     "overrides": {
       "postcss@<8.5.23": "8.5.23",
       "tar@<=7.5.20": "7.5.21",
@@ -38,5 +43,12 @@
       "brace-expansion@>=4.0.0 <5.0.8": "5.0.9"
     }
   },
-  "packageManager": "pnpm@10.14.0"
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "24.19.0",
+      "onFail": "download"
+    }
+  },
+  "packageManager": "pnpm@10.34.5"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       lint-staged:
         specifier: ^17.0.8
         version: 17.0.8
+      node:
+        specifier: runtime:24.19.0
+        version: runtime:24.19.0
       prettier:
         specifier: ^3.0.0
         version: 3.6.2
@@ -68,8 +71,8 @@ importers:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.5.1)
       eslint-config-next:
-        specifier: 16.2.10
-        version: 16.2.10(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2))(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2)
+        specifier: 16.2.11
+        version: 16.2.11(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2))(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2)
       tailwindcss:
         specifier: ^4
         version: 4.1.12
@@ -198,9 +201,6 @@ packages:
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
-  '@emnapi/runtime@1.4.5':
-    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
-
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
@@ -301,89 +301,105 @@ packages:
     resolution: {integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.3.0':
     resolution: {integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.3.0':
     resolution: {integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.3.0':
     resolution: {integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.3.0':
     resolution: {integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.3.0':
     resolution: {integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
     resolution: {integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.3.0':
     resolution: {integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.35.0':
     resolution: {integrity: sha512-4+4XHLNT5wDT0roYlHTEmH9lDKt0acf9Tv+3hM3iceOirkxrR404/3WjAYZ9F9CkHrxeRcGLJXbi4vluMZ9O+A==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.35.0':
     resolution: {integrity: sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==}
     engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.35.0':
     resolution: {integrity: sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==}
     engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.35.0':
     resolution: {integrity: sha512-l6vmKVPnbS0RhVMbyxP5meAARsbhCnBN4fy31qz0+3a6Rv4jEqfzDrT89y6ZPkCi0AJGnwp2En528yXo401Hpw==}
     engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.35.0':
     resolution: {integrity: sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==}
     engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.35.0':
     resolution: {integrity: sha512-TYaItB5oj1ioXjhyn2xrR208vf+YuIIcHptQWRRaBmFhvIvL9D72DXN8w75xup0KXA8UdEAhQ9Qb2S49FD/9Cw==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.35.0':
     resolution: {integrity: sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==}
     engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.35.0':
     resolution: {integrity: sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==}
     engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.35.0':
     resolution: {integrity: sha512-9woLIFORERCr+6cWu87dQ22J34EExkhc73U1kZW0c+RclQqWetoodByp4dWZ/hN8/KVmTRAx2HOnUwib8AwZdA==}
@@ -438,8 +454,8 @@ packages:
   '@next/env@16.2.11':
     resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
-  '@next/eslint-plugin-next@16.2.10':
-    resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
+  '@next/eslint-plugin-next@16.2.11':
+    resolution: {integrity: sha512-vMEf/aXOpzFFdtIvFYOnIDPKb0xBbrXONsz83CcKdRrekfxNdL8PNkq5qHqAHSXVlIifnX68LOMaxr3z5PkeLQ==}
 
   '@next/swc-darwin-arm64@16.2.11':
     resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
@@ -458,24 +474,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -549,24 +569,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -758,41 +782,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1123,8 +1155,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-config-next@16.2.10:
-    resolution: {integrity: sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==}
+  eslint-config-next@16.2.11:
+    resolution: {integrity: sha512-FIpbK/dUyxUExchDB7eBg3k+VU8R2iR/Cx9/kqTBUTFv2bOIR9aRrpno4rvAQ9VhiPQAyFKNA2NlZwouGWtclA==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -1618,24 +1650,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -1757,6 +1793,96 @@ packages:
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
+
+  node@runtime:24.19.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-9ONcExZd5ogMqiVYwKpIyoitpH/iI0vtB9Ztu4CkfI0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-gpS3qpsDmXSBwGur8eiycMhZNY8n2lehFQmv5TesOB0=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-0bXpmdsVjGL+j3JnpEdrA12L2TsaYFusJKPw3RZuMxY=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-0oyKW/CoCPDtQ0odzoxUrpjwNxwL2GrFirxhP3PmZD8=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-sxqMTLxYn5FS8y/bQxhGl1nhZViltdk7f/L7KHsBPbI=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-s6tqQ5KCjbn9TtloOY1VGIKSvMFYGVQtU74LEQDjMvw=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-9iXZfNcH30/5YlSRb7xf8BTwnAnv/loeDKj21BqHidQ=
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-hQL0pQtFjUzDjtjyABVWws0jnUZJIPdAF5Jsyx4cFX8=
+            prefix: node-v24.19.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-V/cas2UueX2ErN3HnIHMn/HG3bKhl0zbg/AP7pv/THM=
+            prefix: node-v24.19.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.19.0/node-v24.19.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+    version: 24.19.0
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2335,11 +2461,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.4.5':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
@@ -2542,13 +2663,13 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.0
     optional: true
 
   '@next/env@16.2.11': {}
 
-  '@next/eslint-plugin-next@16.2.10':
+  '@next/eslint-plugin-next@16.2.11':
     dependencies:
       fast-glob: 3.3.1
 
@@ -3244,9 +3365,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.2.10(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2))(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2):
+  eslint-config-next@16.2.11(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2))(eslint@9.39.5(jiti@2.5.1))(typescript@5.9.2):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.10
+      '@next/eslint-plugin-next': 16.2.11
       eslint: 9.39.5(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.5.1))
@@ -3936,6 +4057,8 @@ snapshots:
       - babel-plugin-macros
 
   node-releases@2.0.51: {}
+
+  node@runtime:24.19.0: {}
 
   object-assign@4.1.1: {}
 

--- a/scripts/check-dependency-build-policy.mjs
+++ b/scripts/check-dependency-build-policy.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("..", import.meta.url)));
+const readText = (relativePath) =>
+  readFileSync(resolve(root, relativePath), "utf8");
+const readJson = (relativePath) => JSON.parse(readText(relativePath));
+const fail = (message) => {
+  console.error(`dependency build policy FAILED: ${message}`);
+  process.exitCode = 1;
+};
+const equalSets = (left, right) =>
+  left.size === right.size && [...left].every((value) => right.has(value));
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const sha256 = (path) =>
+  createHash("sha256").update(readFileSync(path)).digest("hex");
+
+const packageJson = readJson("package.json");
+const architecture = readJson("docs/ARCHITECTURE.yaml");
+const policy = architecture.architecture.dependency_lifecycle_policy;
+const runtimePolicy = architecture.architecture.node_runtime_policy;
+const lock = readText("pnpm-lock.yaml");
+const workspace = readText("pnpm-workspace.yaml");
+
+const versionsInLock = (name) => {
+  const pattern = new RegExp(
+    `^  ['"]?${escapeRegex(name)}@([^'":]+)['"]?:$`,
+    "gm",
+  );
+  return new Set([...lock.matchAll(pattern)].map((match) => match[1]));
+};
+
+const packageRoot = (name, version) => {
+  const virtualName = name.replace("/", "+");
+  const packageParts = name.split("/");
+  return resolve(
+    root,
+    "node_modules/.pnpm",
+    `${virtualName}@${version}`,
+    "node_modules",
+    ...packageParts,
+  );
+};
+
+const expectHash = (path, expected, label) => {
+  let actual;
+  try {
+    actual = sha256(path);
+  } catch (error) {
+    fail(`${label} is unreadable at ${path}: ${error.message}`);
+    return;
+  }
+  if (actual !== expected) {
+    fail(`${label} SHA-256 ${actual} does not match reviewed ${expected}`);
+  }
+};
+
+if (packageJson.packageManager !== policy.package_manager) {
+  fail(
+    `packageManager ${packageJson.packageManager} does not match ${policy.package_manager}`,
+  );
+}
+
+const expectedPnpmVersion = policy.package_manager.replace("pnpm@", "");
+const userAgent = process.env.npm_config_user_agent ?? "";
+if (!userAgent.startsWith(`pnpm/${expectedPnpmVersion} `)) {
+  fail(
+    `policy must run through pnpm ${expectedPnpmVersion}; npm_config_user_agent=${JSON.stringify(userAgent)}`,
+  );
+}
+
+const pnpmConfig = packageJson.pnpm ?? {};
+const forbiddenAllowControls = [
+  "allowBuilds",
+  "dangerouslyAllowAllBuilds",
+  "neverBuiltDependencies",
+  "onlyBuiltDependencies",
+  "onlyBuiltDependenciesFile",
+];
+for (const setting of forbiddenAllowControls) {
+  if (Object.hasOwn(pnpmConfig, setting)) {
+    fail(`package.json pnpm.${setting} is forbidden by deny-only policy`);
+  }
+  if (new RegExp(`^\\s*${setting}:`, "m").test(workspace)) {
+    fail(`pnpm-workspace.yaml ${setting} is forbidden by deny-only policy`);
+  }
+}
+
+const configuredDenied = new Set(pnpmConfig.ignoredBuiltDependencies ?? []);
+const reviewedDenied = new Set(Object.keys(policy.denied_packages));
+if (!equalSets(configuredDenied, reviewedDenied)) {
+  fail(
+    `ignoredBuiltDependencies ${JSON.stringify([...configuredDenied].sort())} does not match reviewed policy ${JSON.stringify([...reviewedDenied].sort())}`,
+  );
+}
+
+const configuredRuntime = packageJson.devEngines?.runtime;
+const expectedRuntime = {
+  name: "node",
+  version: runtimePolicy.managed_runtime.replace("node@", ""),
+  onFail: "download",
+};
+if (JSON.stringify(configuredRuntime) !== JSON.stringify(expectedRuntime)) {
+  fail(
+    `devEngines.runtime ${JSON.stringify(configuredRuntime)} does not match ${JSON.stringify(expectedRuntime)}`,
+  );
+}
+
+for (const [name, evidence] of Object.entries(policy.denied_packages)) {
+  if (evidence.decision !== "deny") {
+    fail(`${name} has non-deny decision ${evidence.decision}`);
+    continue;
+  }
+
+  const versions = versionsInLock(name);
+  if (!equalSets(versions, new Set([evidence.version]))) {
+    fail(
+      `${name} lock versions ${JSON.stringify([...versions].sort())} do not match reviewed ${evidence.version}`,
+    );
+    continue;
+  }
+
+  const installedRoot = packageRoot(name, evidence.version);
+  const manifestPath = resolve(installedRoot, "package.json");
+  expectHash(manifestPath, evidence.manifest_sha256, `${name} package.json`);
+
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    fail(`${name} package.json cannot be parsed: ${error.message}`);
+    continue;
+  }
+  if (manifest.scripts?.postinstall !== evidence.lifecycle_command) {
+    fail(
+      `${name} postinstall ${JSON.stringify(manifest.scripts?.postinstall)} does not match reviewed ${JSON.stringify(evidence.lifecycle_command)}`,
+    );
+  }
+
+  if (evidence.support_package) {
+    const support = evidence.support_package;
+    const supportVersions = versionsInLock(support.name);
+    if (!equalSets(supportVersions, new Set([support.version]))) {
+      fail(
+        `${support.name} lock versions ${JSON.stringify([...supportVersions].sort())} do not match reviewed ${support.version}`,
+      );
+      continue;
+    }
+    const supportRoot = packageRoot(support.name, support.version);
+    expectHash(
+      resolve(supportRoot, "package.json"),
+      support.manifest_sha256,
+      `${support.name} package.json`,
+    );
+    const actualLibFiles = readdirSync(resolve(supportRoot, "lib"), {
+      withFileTypes: true,
+    })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".js"))
+      .map((entry) => `lib/${entry.name}`)
+      .sort();
+    if (JSON.stringify(actualLibFiles) !== JSON.stringify(support.lib_files)) {
+      fail(
+        `${support.name} executable files ${JSON.stringify(actualLibFiles)} do not match reviewed ${JSON.stringify(support.lib_files)}`,
+      );
+    }
+    const treeHash = createHash("sha256");
+    for (const relativePath of actualLibFiles) {
+      treeHash.update(relativePath);
+      treeHash.update("\0");
+      treeHash.update(readFileSync(resolve(supportRoot, relativePath)));
+      treeHash.update("\0");
+    }
+    const actualTreeHash = treeHash.digest("hex");
+    if (actualTreeHash !== support.lib_tree_sha256) {
+      fail(
+        `${support.name} executable tree SHA-256 ${actualTreeHash} does not match reviewed ${support.lib_tree_sha256}`,
+      );
+    }
+    expectHash(
+      resolve(supportRoot, "lib/cli.js"),
+      support.cli_sha256,
+      `${support.name} lib/cli.js`,
+    );
+    if (support.cli_sha256 !== evidence.script_sha256) {
+      fail(`${name} script_sha256 must identify ${support.name} lib/cli.js`);
+    }
+  } else {
+    expectHash(
+      resolve(installedRoot, "scripts/install.js"),
+      evidence.script_sha256,
+      `${name} scripts/install.js`,
+    );
+  }
+}
+
+const npmExecPath = process.env.npm_execpath;
+let moduleState;
+try {
+  moduleState = readJson("node_modules/.modules.yaml");
+} catch (error) {
+  fail(`pnpm module state is unreadable: ${error.message}`);
+}
+if (moduleState) {
+  if (moduleState.packageManager !== policy.package_manager) {
+    fail(
+      `node_modules package manager ${moduleState.packageManager} does not match ${policy.package_manager}`,
+    );
+  }
+  if (!Array.isArray(moduleState.pendingBuilds)) {
+    fail("pnpm module state does not expose pendingBuilds");
+  } else if (moduleState.pendingBuilds.length > 0) {
+    fail(
+      `pnpm has unreviewed pending builds: ${JSON.stringify(moduleState.pendingBuilds)}`,
+    );
+  }
+}
+
+if (!npmExecPath) {
+  fail("npm_execpath is missing; invoke through pnpm run");
+} else {
+  const ignoredBuildsEnv = { ...process.env };
+  for (const name of Object.keys(ignoredBuildsEnv)) {
+    if (name.startsWith("npm_") || name.startsWith("PNPM_")) {
+      delete ignoredBuildsEnv[name];
+    }
+  }
+  const ignoredBuilds = spawnSync(npmExecPath, ["ignored-builds"], {
+    cwd: root,
+    encoding: "utf8",
+    env: ignoredBuildsEnv,
+  });
+  if (ignoredBuilds.status !== 0) {
+    fail(
+      `pnpm ignored-builds via ${npmExecPath} failed: ${ignoredBuilds.stderr || ignoredBuilds.stdout}`,
+    );
+  } else {
+    const output = ignoredBuilds.stdout;
+    const reportsNone =
+      /Automatically ignored builds during installation:\s+None/.test(output);
+    const cannotIdentify = output.includes(
+      "Cannot identify as no node_modules found",
+    );
+    if (!reportsNone && !cannotIdentify) {
+      fail(
+        `pnpm reports unreviewed automatically ignored builds via ${npmExecPath}:\n${output}`,
+      );
+    }
+    for (const name of reviewedDenied) {
+      if (!output.includes(name)) {
+        fail(
+          `pnpm ignored-builds output does not confirm explicit denial of ${name}`,
+        );
+      }
+    }
+  }
+}
+
+if (!process.exitCode) {
+  console.log(
+    `dependency build policy OK: denied=${[...reviewedDenied].sort().join(",")} runtime=${runtimePolicy.managed_runtime}`,
+  );
+}

--- a/tests/architecture/test_node_tooling_contract.py
+++ b/tests/architecture/test_node_tooling_contract.py
@@ -1,0 +1,184 @@
+"""Executable monorepo tooling and dependency-lifecycle contracts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_ACTIONS = {
+    "actions/checkout": (
+        "3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "v7.0.1",
+    ),
+    "actions/setup-node": (
+        "820762786026740c76f36085b0efc47a31fe5020",
+        "v7.0.0",
+    ),
+    "actions/setup-python": (
+        "5fda3b95a4ea91299a34e894583c3862153e4b97",
+        "v7.0.0",
+    ),
+    "pnpm/action-setup": (
+        "0977fd99725f1db4007ccb2928dbb4e90d06cc86",
+        "v6.0.10",
+    ),
+}
+
+EXPECTED_DENIED_BUILDS = {
+    "@tailwindcss/oxide": {
+        "version": "4.1.12",
+        "decision": "deny",
+        "lifecycle_command": "node ./scripts/install.js",
+        "manifest_sha256": "19e31a0bc5fa826d5f4c1a73fa2d7e821e3ed826f86d28987618bc18c0a3a656",
+        "script_sha256": "df8750369bdc91787de5baec99eaaf27b7d8d2952acb25cf1a0b0aa511185b2a",
+    },
+    "unrs-resolver": {
+        "version": "1.11.1",
+        "decision": "deny",
+        "lifecycle_command": "napi-postinstall unrs-resolver 1.11.1 check",
+        "manifest_sha256": "0510c5611b2c4436d12364dff5ddd0f227dacd174cadd62141b226bce1fa4b19",
+        "script_sha256": "2d79f5b3ee7566309a587c267ab8363881f5ebe97a728b0271fb530569b1f356",
+        "support_package": {
+            "name": "napi-postinstall",
+            "version": "0.3.3",
+            "manifest_sha256": "94d75d361fd158062dd3888ca0bd3abc90d67ef0f5f746d4b7b0de9065a384bd",
+            "lib_files": [
+                "lib/cli.js",
+                "lib/constants.js",
+                "lib/fallback.js",
+                "lib/helpers.js",
+                "lib/index.js",
+                "lib/target.js",
+                "lib/types.js",
+            ],
+            "lib_tree_sha256": "f2b5f747776727b0bf13220d49407cd0523d180842a09df3bc2e2f2e9116e3d8",
+            "cli_sha256": "2d79f5b3ee7566309a587c267ab8363881f5ebe97a728b0271fb530569b1f356",
+        },
+    },
+}
+
+
+def _json(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_node_and_pnpm_runtimes_are_exact_and_managed() -> None:
+    package = _json("package.json")
+
+    assert package["packageManager"] == "pnpm@10.34.5"
+    assert package["devEngines"]["runtime"] == {
+        "name": "node",
+        "version": "24.19.0",
+        "onFail": "download",
+    }
+    assert package["scripts"]["prepare"] == "husky"
+    assert package["scripts"]["check:dependency-build-policy"] == (
+        "node scripts/check-dependency-build-policy.mjs"
+    )
+
+
+def test_dependency_build_scripts_are_explicitly_denied_and_pinned() -> None:
+    package = _json("package.json")
+    architecture = _json("docs/ARCHITECTURE.yaml")
+    policy = architecture["architecture"]["dependency_lifecycle_policy"]
+
+    assert set(package["pnpm"]["ignoredBuiltDependencies"]) == set(
+        EXPECTED_DENIED_BUILDS
+    )
+    assert policy["package_manager"] == "pnpm@10.34.5"
+    assert policy["denied_packages"] == EXPECTED_DENIED_BUILDS
+    assert policy["verification_command"] == "pnpm run check:dependency-build-policy"
+
+    lock = (ROOT / "pnpm-lock.yaml").read_text(encoding="utf-8")
+    for name, evidence in EXPECTED_DENIED_BUILDS.items():
+        escaped = re.escape(name)
+        versions = set(
+            re.findall(rf"^  ['\"]?{escaped}@([^'\":]+)['\"]?:$", lock, re.MULTILINE)
+        )
+        assert versions == {evidence["version"]}, (name, versions)
+
+
+def test_dependency_policy_checker_validates_reviewed_bytes_and_pnpm_state() -> None:
+    checker = (ROOT / "scripts/check-dependency-build-policy.mjs").read_text(
+        encoding="utf-8"
+    )
+
+    for required_guard in (
+        "createHash",
+        "manifest_sha256",
+        "script_sha256",
+        "support_package",
+        "lib_tree_sha256",
+        "lib_files",
+        "npm_execpath",
+        "ignored-builds",
+        ".modules.yaml",
+        "pendingBuilds",
+        "dangerouslyAllowAllBuilds",
+        "onlyBuiltDependencies",
+        "allowBuilds",
+    ):
+        assert required_guard in checker
+
+
+def test_ci_checks_dependency_build_policy_after_each_workspace_install() -> None:
+    workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("pnpm install --frozen-lockfile") == 2
+    assert workflow.count("pnpm run check:dependency-build-policy") == 2
+    assert workflow.count("version: 10.34.5") == 2
+    assert workflow.count("node-version: 24.19.0") == 2
+
+
+def test_optional_api_has_no_placeholder_build_task() -> None:
+    api_package = _json("apps/api/package.json")
+
+    assert "build" not in api_package["scripts"]
+
+
+def test_machine_architecture_json_is_not_reformatted_as_yaml() -> None:
+    ignored = (ROOT / ".prettierignore").read_text(encoding="utf-8").splitlines()
+
+    assert {"docs/ARCHITECTURE.yaml", "pnpm-lock.yaml"} <= set(ignored)
+
+
+def test_workflow_actions_use_reviewed_node24_releases() -> None:
+    workflow_paths = sorted((ROOT / ".github/workflows").glob("*.yml"))
+    seen: dict[str, list[tuple[str, str, str]]] = {
+        action: [] for action in EXPECTED_ACTIONS
+    }
+
+    pattern = re.compile(
+        r"uses:\s*([\w.-]+/[\w.-]+)@([0-9a-f]{40})\s+#\s+(v[^\s]+)"
+    )
+    for path in workflow_paths:
+        for action, sha, tag in pattern.findall(path.read_text(encoding="utf-8")):
+            if action in seen:
+                seen[action].append((sha, tag, path.name))
+
+    for action, (expected_sha, expected_tag) in EXPECTED_ACTIONS.items():
+        assert seen[action], f"{action} is not used"
+        assert all(
+            sha == expected_sha and tag == expected_tag
+            for sha, tag, _path in seen[action]
+        ), (action, seen[action])
+
+
+def test_node26_tailwind_blocker_and_removal_trigger_are_documented() -> None:
+    architecture = _json("docs/ARCHITECTURE.yaml")
+    runtime = architecture["architecture"]["node_runtime_policy"]
+    prose = (ROOT / "docs/ARCHITECTURE.md").read_text(encoding="utf-8")
+
+    assert runtime == {
+        "managed_runtime": "node@24.19.0",
+        "reason": "Tailwind CSS 4 emits Node DEP0205 under Node 26",
+        "upstream_issue": "https://github.com/tailwindlabs/tailwindcss/issues/19893",
+        "removal_trigger": (
+            "upgrade after a stable Tailwind release replaces module.register and the "
+            "Node 26 strict build is warning-free"
+        ),
+    }
+    assert runtime["upstream_issue"] in prose


### PR DESCRIPTION
## Summary

- pin `pnpm@10.34.5` and pnpm-managed `node@24.19.0` across local and CI execution;
- explicitly deny the reviewed `@tailwindcss/oxide@4.1.12` and `unrs-resolver@1.11.1` native fallback hooks instead of approving network-capable postinstalls;
- add a fail-closed checker for exact package manager/runtime identity, lock versions, package manifests, lifecycle commands, the complete `napi-postinstall@0.3.3` executable JS tree, forbidden allow controls, and pending builds;
- replace deprecated `husky install` with Husky 9's maintained `husky` prepare command;
- remove the echo-only FastAPI package build and its false Turborepo output claim;
- align direct Next.js and eslint-config-next declarations to the executed 16.2.11 lock;
- update checkout/setup-node/setup-python/pnpm setup actions to reviewed Node-24-backed releases at full commit SHAs;
- add CI lifecycle-policy verification after both workspace installs;
- document the warning-free toolchain, lifecycle decisions, upstream Tailwind Node 26 removal trigger, and exact commands.

## Security decision

No dependency lifecycle script is approved.

- Oxide's reviewed postinstall can download and extract a registry fallback.
- unrs-resolver invokes napi-postinstall, which can run npm or download a native fallback.
- The locked optional native packages load and the full lint/build matrix passes while both hooks remain denied.
- Future package, script-byte, support-package, allow-control, or pending-build drift fails closed.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run check:dependency-build-policy`
- `corepack pnpm audit --audit-level high`: no known vulnerabilities
- uncached `pnpm test`: API 20 passed; web command passed
- uncached `pnpm run lint`
- uncached `pnpm run typecheck`
- uncached `pnpm run build`: Next.js 16.2.11 static build passed with no DEP0205 or Turborepo output warning
- `pytest tests/architecture -q`: 21 passed
- portfolio architecture, AI hierarchy, and adversarial hierarchy self-tests passed
- Pinact passed; Zizmor 1.28.0 reported no findings
- changed-file Prettier check passed
- Markdown link audit: 24 files, zero findings
- `git diff --check`
- two independent adversarial review rounds; final lifecycle and formatting blocker checks passed

## Upstream removal trigger

Tailwind issue https://github.com/tailwindlabs/tailwindcss/issues/19893 tracks Node 26 `module.register()` deprecation. Remove managed Node 24 only after a stable Tailwind release is warning-free under an uncached Node 26 build; no warning suppression is used here.

Closes #101
